### PR TITLE
feat(openshift) cluster internal oidc

### DIFF
--- a/openshift/shared/cosign/k8s-oidc-cronjob.yaml
+++ b/openshift/shared/cosign/k8s-oidc-cronjob.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: tas-test-sign-verify
+  name: k8s-tas-test-sign-verify
 spec:
   schedule: "*/10 * * * *"
   jobTemplate:
@@ -42,8 +42,8 @@ spec:
                 - |
                   set -e
                   TOKEN=$(cat $TOKEN_PATH)
-                  PAYLOAD=$(echo $TOKEN | cut -d '.' -f2 | tr '_-' '/+' | base64 -d 2>/dev/null)
-
+                  PAYLOAD_BASE64=$(echo "$TOKEN" | cut -d '.' -f2 | tr '_-' '/+') 
+                  PAYLOAD=$(echo "$PAYLOAD_BASE64=" | base64 -d)
                   OIDC_ISSUER=$(echo "$PAYLOAD" | sed -n 's/.*"iss":"\([^"]*\)".*/\1/p')
 
                   echo "OIDC Issuer: $OIDC_ISSUER"

--- a/openshift/shared/cosign/kustomization.yaml
+++ b/openshift/shared/cosign/kustomization.yaml
@@ -3,4 +3,5 @@ kind: Kustomization
 
 resources:
 - keycloak-oidc-cronjob.yaml
+- k8s-oidc-cronjob.yaml
 


### PR DESCRIPTION
## Summary by Sourcery

Introduce a dedicated OpenShift CronJob to perform internal OIDC token signing and verification for Cosign, update its script to robustly decode JWT payloads, and register it in the kustomization manifest.

New Features:
- Add k8s-tas-test-sign-verify CronJob for OIDC Cosign token signing and verification

Enhancements:
- Improve JWT payload extraction by splitting out base64 segment and handling padding for reliable decoding

Chores:
- Add the new k8s-oidc-cronjob.yaml resource to the kustomization configuration