### PR TITLE
fix: deserialisation of base64url content of oidc token

### DIFF
--- a/openshift/shared/cosign/k8s-oidc-cronjob.yaml
+++ b/openshift/shared/cosign/k8s-oidc-cronjob.yaml
@@ -37,13 +37,15 @@ spec:
                   value: "https://tuf-$(NAMESPACE).${APPS_DOMAIN}"
                 - name: TOKEN_PATH
                   value: "/var/run/secrets/tokens/oidc-token"
+                - name: SSL_CERT_DIR
+                  value: /var/run/secrets/kubernetes.io/serviceaccount
               command: ["/bin/sh", "-c"]
               args:
                 - |
-                  set -e
+                  set -e -u -o pipefail
                   TOKEN=$(cat $TOKEN_PATH)
-                  PAYLOAD_BASE64=$(echo "$TOKEN" | cut -d '.' -f2 | tr '_-' '/+') 
-                  PAYLOAD=$(echo "$PAYLOAD_BASE64=" | base64 -d)
+                  PAYLOAD_BASE64URL=$(echo "$TOKEN" | cut -d '.' -f2) 
+                  PAYLOAD=$(echo "$PAYLOAD_BASE64URL" | basenc --base64url -d)
                   OIDC_ISSUER=$(echo "$PAYLOAD" | sed -n 's/.*"iss":"\([^"]*\)".*/\1/p')
 
                   echo "OIDC Issuer: $OIDC_ISSUER"

--- a/openshift/shared/securesign/securesign.yaml
+++ b/openshift/shared/securesign/securesign.yaml
@@ -30,7 +30,7 @@ spec:
           Type: email
       MetaIssuers:
         - ClientID: sigstore
-          Issuer: "https://rh-oidc.*.*.amazonaws.com/*"
+          Issuer: "https://*.*.*.amazonaws.com/*"
           Type: kubernetes
 #        - ClientID: sigstore
 #          Issuer: "https://kubernetes.*.svc"


### PR DESCRIPTION
## Summary by Sourcery

Fix OIDC token payload decoding in the k8s cronjob and update Securesign issuer pattern to broad AWS domains

Bug Fixes:
- Use basenc --base64url to correctly decode the OIDC token payload
- Enable strict shell settings (pipefail and unset variable checks) in the cronjob

Enhancements:
- Add SSL_CERT_DIR environment variable to the cronjob container for certificate resolution
- Broaden the AWS issuer regex in Securesign configuration to match all subdomains