### PR TITLE
fix: use pause image to avoid rate limits in sign/verify cronjobs

### DIFF
--- a/openshift/shared/cosign/k8s-oidc-cronjob.yaml
+++ b/openshift/shared/cosign/k8s-oidc-cronjob.yaml
@@ -55,7 +55,7 @@ spec:
                   
                   IMAGE_NAME=$(head /dev/urandom | tr -dc 'a-z0-9' | head -c 16)
                   IMAGE=ttl.sh/$IMAGE_NAME:2min
-                  cosign copy "mirror.gcr.io/alpine:latest" $IMAGE
+                  cosign copy --platform linux/amd64 "registry.k8s.io/pause:3.9" $IMAGE
                   
                   cosign sign -y --fulcio-url=$FULCIO_URL --rekor-url=$REKOR_URL --identity-token=$TOKEN $IMAGE
                   

--- a/openshift/shared/cosign/keycloak-oidc-cronjob.yaml
+++ b/openshift/shared/cosign/keycloak-oidc-cronjob.yaml
@@ -52,7 +52,7 @@ spec:
                   
                   IMAGE_NAME=$(head /dev/urandom | tr -dc 'a-z0-9' | head -c 16)
                   IMAGE=ttl.sh/$IMAGE_NAME:2min
-                  cosign copy "mirror.gcr.io/alpine:latest" $IMAGE
+                  cosign copy --platform linux/amd64 "registry.k8s.io/pause:3.9" $IMAGE
                   
                   cosign sign -y --fulcio-url=$FULCIO_URL --rekor-url=$REKOR_URL --timestamp-server-url=$TSA_URL/api/v1/timestamp --identity-token=$TOKEN --oidc-issuer=$OIDC_ISSUER_URL --oidc-client-id=trusted-artifact-signer $IMAGE
                   sleep 5


### PR DESCRIPTION
### **User description**
Replace mirror.gcr.io/alpine:latest with registry.k8s.io/pause:3.9 and add --platform linux/amd64 flag to cosign copy command.

This fixes TOOMANYREQUESTS errors from mirror.gcr.io quota limits and reduces API calls by avoiding multi-arch manifest fetches.


___

### **PR Type**
Bug fix


___

### **Description**
- Replace mirror.gcr.io/alpine with registry.k8s.io/pause:3.9

- Add --platform linux/amd64 flag to cosign copy command

- Fixes TOOMANYREQUESTS errors from mirror.gcr.io quota limits

- Reduces API calls by avoiding multi-arch manifest fetches


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["mirror.gcr.io/alpine:latest"] -->|"Replace with"| B["registry.k8s.io/pause:3.9"]
  C["cosign copy command"] -->|"Add --platform linux/amd64"| D["Single-arch image fetch"]
  B -->|"Result"| E["Avoid rate limit errors"]
  D -->|"Result"| E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>k8s-oidc-cronjob.yaml</strong><dd><code>Update image and add platform flag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openshift/shared/cosign/k8s-oidc-cronjob.yaml

<ul><li>Replace mirror.gcr.io/alpine:latest with registry.k8s.io/pause:3.9<br> <li> Add --platform linux/amd64 flag to cosign copy command<br> <li> Reduces quota limit errors and API calls</ul>


</details>


  </td>
  <td><a href="https://github.com/securesign/quickstarts/pull/12/files#diff-c34f8bcf0e5d26f917d7a4ef4dca5a5b3696636222ceb5161e6366ee8f657f21">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>keycloak-oidc-cronjob.yaml</strong><dd><code>Update image and add platform flag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openshift/shared/cosign/keycloak-oidc-cronjob.yaml

<ul><li>Replace mirror.gcr.io/alpine:latest with registry.k8s.io/pause:3.9<br> <li> Add --platform linux/amd64 flag to cosign copy command<br> <li> Reduces quota limit errors and API calls</ul>


</details>


  </td>
  <td><a href="https://github.com/securesign/quickstarts/pull/12/files#diff-90310e47b517d25bed445fd5cdbd101f88a9dbcd01aa25773a9b325491b8ccc5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

