### PR TITLE
fix: bump sail operator version

### DIFF
--- a/openshift/shared/ossm/instances/istio-cni.yaml
+++ b/openshift/shared/ossm/instances/istio-cni.yaml
@@ -4,4 +4,4 @@ metadata:
   name: default
 spec:
   namespace: istio-cni
-  version: v1.24-latest
+  version: v1.28-latest

--- a/openshift/shared/ossm/instances/istio.yaml
+++ b/openshift/shared/ossm/instances/istio.yaml
@@ -12,4 +12,4 @@ spec:
       discoverySelectors:
         - matchLabels:
             istio-discovery: enabled
-  version: v1.24-latest
+  version: v1.28-latest


### PR DESCRIPTION
When running the make deploy-all command for the openshift/api-gateway quickstart I got this error
```
Error from server (Invalid): error when creating "STDIN": Istio.sailoperator.io "default" is invalid: [spec.version: Unsupported value: "v1.24-latest": supported values: "v1.28-latest", "v1.28.4", "v1.27-latest", "v1.27.5", "v1.27.3", "v1.26-latest", "v1.26.8", "v1.26.6", "v1.26.4", "v1.26.3", "v1.26.2", <nil>: Invalid value: "null": some validation rules were not checked because the object was invalid; correct the existing errors to complete validation]
Error from server (Invalid): error when creating "STDIN": IstioCNI.sailoperator.io "default" is invalid: [spec.version: Unsupported value: "v1.24-latest": supported values: "v1.28-latest", "v1.28.4", "v1.27-latest", "v1.27.5", "v1.27.3", "v1.26-latest", "v1.26.8", "v1.26.6", "v1.26.4", "v1.26.3", "v1.26.2", <nil>: Invalid value: "null": some validation rules were not checked because the object was invalid; correct the existing errors to complete validation]
make: *** [Makefile:53: install-istio] Error 1
```